### PR TITLE
Remove perl5lib path dependencies, resolve compiling issues, revise readme

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,11 @@
-LDFLAGS=-L/usr/X11R6/lib -lX11
-CFLAGS=-Wall -I/usr/X11R6/include -O3
+CC=gcc
+CFLAGS=-Wall -lX11
+DEPS=
+OBJ = imlib.o \
+	  screen_capture.o
 
-screen_capture:screen_capture.c imlib.o
-clean:
-	$(RM) screen_capture
+$%.o: %.c $(DEPS)
+	$(CC) -c -o $@ $< $(CFLAGS)
+
+screen_capture: $(OBJ)
+	gcc -o $@ $^ $(CFLAGS)

--- a/README.md
+++ b/README.md
@@ -5,15 +5,18 @@
   libgif, cpan, gifsicle
 
   To get above requirements, in Ubuntu, just run
-
-    sudo apt-get install libgif-dev gifsicle
-    cpan install Imager::Screenshot Const::Fast
+```
+sudo apt-get install libgif-dev gifsicle
+cpan install Imager::Screenshot Const::Fast
+```
 
   should get all the requirements you need.
 
 - Installation
 
-    make
+```
+make
+```
 
 - Configuration
 
@@ -21,14 +24,14 @@
   screen_cap.pl. You can also easily integrate it with your WM.~~
 
   Only if you have an unique perl5 library path, you have to set up the `PERSONAL_PERL5LIB`
-  and uncomment the line `116` : `sprintf(perl5lib, PERSONAL_PERL5LIB);`.
+  and uncomment the line `116` which is `sprintf(perl5lib, PERSONAL_PERL5LIB);`.
 
 - Usage:
 
   `./screen_capture` will enable selecting rectangle region with `left mouse`
   button after 1sec delay, or capture whole screen when `right mouse` clicked.
   Keyboard will freeze after selection, responding only to `q` and `Esc`.
-  Pressing `q` for the *first time* will _start recording_, pressing for *second time*
+  Pressing `q` for the ***first time*** will _start recording_, pressing for ***second time***
   will _stop the record_ and ouput the animated gif in `/tmp/test.gif`. Pressing
   `Esc` in this process will stop recording immediately and not generate the
   gif.

--- a/README.md
+++ b/README.md
@@ -2,25 +2,39 @@
 
 - Requirements:
 
-  libgif, cpan
+  libgif, cpan, gifsicle
+
+  To get above requirements, in Ubuntu, just run
+
+    sudo apt-get install libgif-dev gifsicle
+    cpan install Imager::Screenshot Const::Fast
+
+  should get all the requirements you need.
 
 - Installation
 
-  make
+    make
 
 - Configuration
 
-  Edit your home path in screen_capture.c and output image size in
-  screen_cap.pl. You can also easily integrate it with your WM.
+  ~~Edit your home path in screen_capture.c and output image size in
+  screen_cap.pl. You can also easily integrate it with your WM.~~
+
+  Only if you have an unique perl5 library path, you have to set up the `PERSONAL_PERL5LIB`
+  and uncomment the line `116` : `sprintf(perl5lib, PERSONAL_PERL5LIB);`.
 
 - Usage:
 
-  ./screen_capture will enable selecting rectangle region with left mouse
-  button after 1sec delay, or capture whole screen when right mouse clicked.
-  Keyboard will freeze after selection, responding only to q and Escape.
-  Pressing q for the first time will start recording, pressing for second time
-  will stop the record and ouput the animated gif in /tmp/test.gif. Pressing
-  Escape in this process will stop recording immediately and not generate the
+  `./screen_capture` will enable selecting rectangle region with `left mouse`
+  button after 1sec delay, or capture whole screen when `right mouse` clicked.
+  Keyboard will freeze after selection, responding only to `q` and `Esc`.
+  Pressing `q` for the *first time* will _start recording_, pressing for *second time*
+  will _stop the record_ and ouput the animated gif in `/tmp/test.gif`. Pressing
+  `Esc` in this process will stop recording immediately and not generate the
   gif.
+
+- TODO:
+  
+  > Make output file being an argument for `screen_capture`.
 
 - ☆★很正常的「ＷＰＩ死宅群」★☆

--- a/screen_cap.pl
+++ b/screen_cap.pl
@@ -7,7 +7,7 @@ use Const::Fast;
 const my %constant=>(max_duration=>20,      # sec
    out_name=>'/tmp/test.gif', fps=>13,      # output filename, frame per sec
    time_rescale_factor => 1.3,
-   resize_option=>'--resize-fit 300x200 --resize-method lanczos3');
+   resize_option=>'--resize-fit 300x200');
 const my $delay=>$constant{time_rescale_factor}/$constant{fps};    # in unit of sec
 const my $max_frames=>$constant{fps}*$constant{max_duration};
 my @frames; my $interrupt=0;

--- a/screen_capture.c
+++ b/screen_capture.c
@@ -4,7 +4,7 @@
 typedef struct{
    int x,y,w,h;
 }rect_t;
-char *home="/home/kkz", perl_script[64];
+char *home="/home/lawliet", perl_script[64];
 Screen* scr;
 
 void setpos(const XButtonEvent*, rect_t*);
@@ -200,7 +200,7 @@ void setpos(const XButtonEvent* but, rect_t* region){
 }
 
 int main(int argc, char **argv) {
-   sprintf(perl_script, "%s/bin/bkup/screen_cap.pl", home);
+   sprintf(perl_script, "./screen_cap.pl");
    if(access(perl_script, F_OK)){
 	fprintf(stderr, "Cannot find script %s\n", perl_script);
 	return 1;

--- a/screen_capture.c
+++ b/screen_capture.c
@@ -113,7 +113,7 @@ void scrot_sel_and_grab_image(void) {
 					// change cursor shape
 				   }else if(pid_capture==0){
 					char top[8], bottom[8], left[8], right[8], perl5lib[32];
-					sprintf(perl5lib, "%s/.perl5/lib/perl5", home);
+					sprintf(perl5lib, "/usr/lib/perl5");
 					sprintf(top,"%d",rect_region.y);
 					sprintf(bottom,"%d",rect_region.y+rect_region.h);
 					sprintf(left,"%d",rect_region.x);

--- a/screen_capture.c
+++ b/screen_capture.c
@@ -4,7 +4,7 @@
 typedef struct{
    int x,y,w,h;
 }rect_t;
-char *home="/home/lawliet", perl_script[64];
+//const char* PERSONAL_PERL5LIB = "/usr/lib/perl5";
 Screen* scr;
 
 void setpos(const XButtonEvent*, rect_t*);
@@ -113,7 +113,7 @@ void scrot_sel_and_grab_image(void) {
 					// change cursor shape
 				   }else if(pid_capture==0){
 					char top[8], bottom[8], left[8], right[8], perl5lib[32];
-					sprintf(perl5lib, "/usr/lib/perl5");
+					//sprintf(perl5lib, PERSONAL_PERL5LIB);
 					sprintf(top,"%d",rect_region.y);
 					sprintf(bottom,"%d",rect_region.y+rect_region.h);
 					sprintf(left,"%d",rect_region.x);


### PR DESCRIPTION
- Make a more straight forward const variable in the c file to indicate userlized perl5 lib path.
- Change compiler from `cc` to `gcc` to resolve `undefined reference` to some `X11` header files.
- Modified readme with steps to install libraries for dependencies.
